### PR TITLE
hw1: the crashing number could be different

### DIFF
--- a/hw/hw1-makefiles-and-gdb/hw1-makefiles-and-gdb.html
+++ b/hw/hw1-makefiles-and-gdb/hw1-makefiles-and-gdb.html
@@ -640,7 +640,7 @@ We know that line 18 is the crashing line. We can print the values of the local 
 $1 = 35824
 </pre>
 
-It is equal to 35824. This should give you enough information for why you crashed. 
+It is equal to 35824(this number might be different on your machine). This should give you enough information for why you crashed. 
 
 <p>Now fix the <tt>crash_array</tt> function to prevent the program from crashing. 
 


### PR DESCRIPTION
The crashing number could be different depends on the machine. Students might get confused if they get a different number.